### PR TITLE
Instantiate the test result for each invocation of the lambda

### DIFF
--- a/lambda-selenium-java/src/main/java/com/blackboard/testing/lambda/LambdaTestHandler.java
+++ b/lambda-selenium-java/src/main/java/com/blackboard/testing/lambda/LambdaTestHandler.java
@@ -17,11 +17,8 @@ public class LambdaTestHandler implements RequestHandler<TestRequest, TestResult
 
     private static TestResult testResult;
 
-    public LambdaTestHandler() {
-        testResult = new TestResult();
-    }
-
     public TestResult handleRequest(TestRequest testRequest, Context context) {
+        testResult = new TestResult();
         LoggerContainer.LOGGER = new Logger(context.getLogger());
         System.setProperty("target.test.uuid", testRequest.getTestRunUUID());
 


### PR DESCRIPTION
If a lambda is pre-warmed, the next request can be contaminated with data from a previous run. This is noticeable where you have a lambda that runs a test and FAILs and then the next invocation of that same lambda runs a test later that is a PASS. That second call will actually fail because the TestResult#throwable field is still retaining the exception from the previous run.

So as it is on master, failing tests will always fail but sometimes passing tests will fail and show the exception of a test that previously failed on the lambda instance calling the handler.